### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.0
+
+### New Features
+
+-   Add the ability to attach a macro to a roll request. The macro context receives an object containing information about the requested roll, the rolling actor and the outcome. See the PR for more information ([#46](https://github.com/In3luki/pf2e-request-rolls/pull/46))
+
+### Enhancements
+
+-   Add `Spell Attack` as option for counteract checks ([#46](https://github.com/In3luki/pf2e-request-rolls/pull/46))
+
 ## 1.1.1
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pf2e-request-rolls",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pf2e-request-rolls",
     "type": "module",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "",
     "private": true,
     "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { GMDialog, RollDialog } from "@module/apps/index.ts";
 import type { SocketRequest } from "@module/apps/types.ts";
 import { htmlClosest } from "@util";
 import * as R from "remeda";
+import { updateDragState } from "./module/apps/gm-dialog/state.svelte.ts";
 import { refreshCSS, registerSettings } from "./settings/register-settings.ts";
 import "./styles/global.scss";
 
@@ -53,6 +54,15 @@ Hooks.once("ready", () => {
             }
         }
     });
+
+    document.addEventListener("drag", (event) => {
+        const data: { type: "Macro"; uuid: string } = JSON.parse(event.dataTransfer?.getData("text/plain") ?? "{}");
+        if (data?.type !== "Macro") {
+            return;
+        }
+        updateDragState(true);
+    });
+    document.addEventListener("dragend", () => updateDragState(false));
 });
 
 Hooks.once("pf2e.systemReady", () => {

--- a/src/module/apps/gm-dialog/gm-dialog.svelte
+++ b/src/module/apps/gm-dialog/gm-dialog.svelte
@@ -75,6 +75,12 @@
         roll.statistic = action?.statistic;
     }
 
+    function onChangeCheck(event: Event & { currentTarget: HTMLSelectElement }, roll: CheckRoll): void {
+        if (roll.against && event.currentTarget.value !== "spell-attack") {
+            delete roll.against;
+        }
+    }
+
     function onClickRoll(event: MouseEvent, group: RequestGroup, roll: RequestRoll): void {
         if (!event.ctrlKey) {
             event.stopPropagation();
@@ -391,7 +397,13 @@
 {#snippet check(roll: CheckRoll)}
     <div class="form-group">
         <label for="check-select-{roll.id}">{game.i18n.localize("PF2E.Roll.Type")}:</label>
-        <select class="check-select" id="check-select-{roll.id}" name="skills" bind:value={roll.slug}>
+        <select
+            class="check-select"
+            id="check-select-{roll.id}"
+            name="skills"
+            bind:value={roll.slug}
+            onchange={(e) => onChangeCheck(e, roll)}
+        >
             <option value="perception">{game.i18n.localize("PF2E.PerceptionHeader")}</option>
             <option value="flat">{game.i18n.localize("PF2E.FlatCheck")}</option>
             <option value="spell-attack">{game.i18n.localize("PF2E.SpellAttackLabel")}</option>
@@ -470,6 +482,7 @@
     <div class="form-group">
         <label for="check-select-{roll.id}">{game.i18n.localize("PF2E.Roll.Type")}:</label>
         <select class="check-select" id="check-select-{roll.id}" name="skills" bind:value={roll.slug}>
+            <option value="spell-attack">{game.i18n.localize("PF2E.SpellAttackLabel")}</option>
             {#each props.skills.skills as skill}
                 <option value={skill.value}>{skill.label}</option>
             {/each}

--- a/src/module/apps/gm-dialog/gm-dialog.svelte
+++ b/src/module/apps/gm-dialog/gm-dialog.svelte
@@ -226,6 +226,29 @@
                 &plus;
             </button>
         </div>
+        {#if selectedGroup.macro || rollRequestState.dragActive}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+                class="macro-drop-zone"
+                class:empty={!selectedGroup.macro}
+                ondrop={(e) => handleMacroDrop(e)}
+                data-tooltip="PF2ERequestRolls.GMDialog.Macros.Tooltip"
+                transition:fade
+            >
+                {#if !selectedGroup.macro}
+                    {localize("GMDialog.Macros.DropHere")}
+                {:else}
+                    <div class="name">
+                        {fu.fromUuidSync(selectedGroup.macro)?.name}
+                    </div>
+                    <div class="controls">
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
+                        <!-- svelte-ignore a11y_no_static_element_interactions -->
+                        <i class="fa-solid fa-trash" onclick={() => delete selectedGroup.macro}></i>
+                    </div>
+                {/if}
+            </div>
+        {/if}
         <div class="add-buttons">
             <button type="button" onclick={() => createNewRoll("action")}>
                 {localize("GMDialog.Buttons.ActionLabel")}
@@ -246,26 +269,6 @@
                 {@render counteract(editing)}
             {/if}
         {/if}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-            class="macro-drop-zone"
-            class:empty={!selectedGroup.macro}
-            ondrop={(e) => handleMacroDrop(e)}
-            data-tooltip="PF2ERequestRolls.GMDialog.Macros.Tooltip"
-        >
-            {#if !selectedGroup.macro}
-                {localize("GMDialog.Macros.DropHere")}
-            {:else}
-                <div class="name">
-                    {fu.fromUuidSync(selectedGroup.macro)?.name}
-                </div>
-                <div class="controls">
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <i class="fa-solid fa-trash" onclick={() => delete selectedGroup.macro}></i>
-                </div>
-            {/if}
-        </div>
     </div>
     <div class="preview">
         {#each requests as request (request.id)}
@@ -600,7 +603,6 @@
             margin-bottom: 0.5em;
 
             &.empty {
-                opacity: 0.75;
                 justify-content: center;
             }
         }

--- a/src/module/apps/gm-dialog/gm-dialog.svelte
+++ b/src/module/apps/gm-dialog/gm-dialog.svelte
@@ -7,9 +7,10 @@
     import { localize } from "@util/misc.ts";
     import TraitsSelect from "@module/components/traits/traits-select.svelte";
     import { compressToBase64, getInlineLink, rollToInline } from "../helpers.ts";
+    import { getNewGroupData, getNewRollData, rollRequestState } from "./state.svelte.ts";
 
     const props: GMDialogContext = $props();
-    const requests: RequestGroup[] = $state(props.initial);
+    const requests = rollRequestState.groups;
     let selectedGroupId = $state(requests[0]?.id ?? "");
     let selectedGroup = $derived(requests.find((r) => r.id === selectedGroupId) ?? requests[0]);
     let selectedRollId: string | null = $state(null);
@@ -27,13 +28,13 @@
         if (requests.length === 1 && requests[0].rolls.length === 0) {
             return;
         }
-        requests.push(props.foundryApp.getNewGroupData());
+        requests.push(getNewGroupData());
         selectedGroupId = requests[requests.length - 1].id;
         selectedRollId = null;
     }
 
     function createNewRoll(type: RequestRoll["type"]): void {
-        selectedGroup.rolls.push(props.foundryApp.getNewRollData(type));
+        selectedGroup.rolls.push(getNewRollData(type));
         selectedRollId = selectedGroup.rolls.at(-1)?.id ?? null;
     }
 
@@ -113,7 +114,7 @@
             if (!confirmed) return;
         }
         untrack(() => (requests.length = 0));
-        requests.push(props.foundryApp.getNewGroupData());
+        requests.push(getNewGroupData());
     }
 
     function switchActive(group: RequestGroup, roll?: RequestRoll): void {
@@ -134,7 +135,7 @@
         if (confirmed) {
             const index = requests.findIndex((r) => r === request);
             if (requests.length === 1) {
-                requests.push(props.foundryApp.getNewGroupData());
+                requests.push(getNewGroupData());
             }
             if (selectedGroupId === request.id) {
                 const newActive = requests.at(Math.max(index - 1, 0));
@@ -162,6 +163,14 @@
             }
             selectedGroup.rolls.findSplice((r) => r === roll);
         }
+    }
+
+    function handleMacroDrop(event: DragEvent & { currentTarget: EventTarget & HTMLDivElement }): void {
+        const data: { type: "Macro"; uuid: string } = JSON.parse(event.dataTransfer?.getData("text/plain") ?? "{}");
+        if (data?.type !== "Macro") {
+            return;
+        }
+        selectedGroup.macro = data.uuid;
     }
 </script>
 
@@ -237,6 +246,26 @@
                 {@render counteract(editing)}
             {/if}
         {/if}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class="macro-drop-zone"
+            class:empty={!selectedGroup.macro}
+            ondrop={(e) => handleMacroDrop(e)}
+            data-tooltip="PF2ERequestRolls.GMDialog.Macros.Tooltip"
+        >
+            {#if !selectedGroup.macro}
+                {localize("GMDialog.Macros.DropHere")}
+            {:else}
+                <div class="name">
+                    {fu.fromUuidSync(selectedGroup.macro)?.name}
+                </div>
+                <div class="controls">
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <i class="fa-solid fa-trash" onclick={() => delete selectedGroup.macro}></i>
+                </div>
+            {/if}
+        </div>
     </div>
     <div class="preview">
         {#each requests as request (request.id)}
@@ -525,6 +554,19 @@
         margin-bottom: 1rem;
     }
 
+    .controls {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        min-width: 1.5em;
+        margin-left: 5px;
+
+        i {
+            cursor: pointer;
+            margin: 0.1em;
+        }
+    }
+
     .edit {
         .add-buttons {
             display: flex;
@@ -543,6 +585,24 @@
 
         .check-select {
             margin-bottom: 5px;
+        }
+
+        .macro-drop-zone {
+            display: flex;
+            flex: 1;
+            align-items: center;
+            justify-content: space-between;
+
+            padding: 0.3em;
+            background-color: var(--pf2e-rr--preview-bg-color);
+            border: 1px solid var(--pf2e-rr--preview-border-color);
+            border-radius: 4px;
+            margin-bottom: 0.5em;
+
+            &.empty {
+                opacity: 0.75;
+                justify-content: center;
+            }
         }
     }
 
@@ -574,19 +634,6 @@
                 &.active {
                     border: 0.1em dashed var(--pf2e-rr--preview-border-color);
                 }
-            }
-        }
-
-        .controls {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            min-width: 1.5em;
-            margin-left: 5px;
-
-            i {
-                cursor: pointer;
-                margin: 0.1em;
             }
         }
 

--- a/src/module/apps/gm-dialog/gm-dialog.ts
+++ b/src/module/apps/gm-dialog/gm-dialog.ts
@@ -12,8 +12,9 @@ import { SvelteApplicationMixin, SvelteApplicationRenderContext } from "../../sv
 import { actionData, decompressFromBase64, getSetting, hasNoContent, rollToInline, skillData } from "../helpers.ts";
 import { ResultsDialog } from "../results-dialog/results-dialog.ts";
 import { type PlayerSelection, SelectPlayersDialog } from "../select-players-dialog/select-players.ts";
-import type { LabeledValue, RequestGroup, RequestHistory, RequestRoll, SocketRollRequest } from "../types.ts";
+import type { LabeledValue, RequestGroup, RequestHistory, SocketRollRequest } from "../types.ts";
 import Root from "./gm-dialog.svelte";
+import { updateGMDialogState } from "./state.svelte.ts";
 
 class GMDialog extends SvelteApplicationMixin<
     AbstractConstructorOf<ApplicationV2> & { DEFAULT_OPTIONS: DeepPartial<GMDialogConfiguration> }
@@ -71,11 +72,12 @@ class GMDialog extends SvelteApplicationMixin<
     }
 
     protected override async _prepareContext(_options: ApplicationRenderOptions): Promise<GMDialogContext> {
+        updateGMDialogState(this.options.initial);
+
         return {
             actions: actionData,
             dcAdjustments: this.#prepareDCAdjustments(),
             foundryApp: this,
-            initial: this.options.initial ?? [this.getNewGroupData()],
             skills: skillData,
             state: {
                 history: fu.deepClone(getSetting("pf2e-request-rolls", "history")).sort((a, b) => b.time - a.time),
@@ -95,48 +97,6 @@ class GMDialog extends SvelteApplicationMixin<
             throw Error("This Application is only usable by GMs!");
         }
         return super._preFirstRender(context, options);
-    }
-
-    getNewGroupData(): RequestGroup {
-        return {
-            id: fu.randomID(),
-            rolls: [],
-            title: "",
-        };
-    }
-
-    getNewRollData(type: RequestRoll["type"]): RequestRoll {
-        switch (type) {
-            case "action":
-                return {
-                    dc: 10,
-                    id: fu.randomID(),
-                    slug: actionData[0].slug,
-                    statistic: actionData[0].statistic,
-                    variant: actionData[0].variants.at(0)?.slug,
-                    type: "action",
-                };
-            case "check":
-                return {
-                    dc: 10,
-                    id: fu.randomID(),
-                    traits: [],
-                    slug: "perception",
-                    type: "check",
-                };
-            case "counteract":
-                return {
-                    dc: 10,
-                    id: fu.randomID(),
-                    label: game.i18n.localize("PF2ERequestRolls.GMDialog.Counteract.Label"),
-                    slug: "arcana",
-                    sourceRank: 0,
-                    targetRank: 0,
-                    type: "counteract",
-                };
-            default:
-                throw Error(`Unknown type ${type}`);
-        }
     }
 
     async sendToChat(groups: RequestGroup[]): Promise<boolean> {
@@ -309,7 +269,6 @@ interface GMDialogContext extends SvelteApplicationRenderContext {
     actions: ActionRenderData[];
     dcAdjustments: LabeledValue[];
     foundryApp: GMDialog;
-    initial: RequestGroup[];
     skills: {
         skills: LabeledValue[];
         lores: LabeledValue[];

--- a/src/module/apps/gm-dialog/state.svelte.ts
+++ b/src/module/apps/gm-dialog/state.svelte.ts
@@ -2,7 +2,7 @@ import { actionData } from "../helpers.ts";
 import type { RequestGroup, RequestRoll } from "../types.ts";
 
 /** The GM Dialog svelte state */
-const rollRequestState: { groups: RequestGroup[] } = $state({ groups: [] });
+const rollRequestState: { dragActive: boolean; groups: RequestGroup[] } = $state({ dragActive: false, groups: [] });
 
 function getNewGroupData(): RequestGroup {
     return {
@@ -54,4 +54,16 @@ function updateGMDialogState(data?: RequestGroup[]): void {
     rollRequestState.groups = data ?? [getNewGroupData()];
 }
 
-export { getNewGroupData, getNewRollData, getRequestGroupsSnapshot, rollRequestState, updateGMDialogState };
+function updateDragState(dragging: boolean): void {
+    if (rollRequestState.dragActive && !dragging) rollRequestState.dragActive = false;
+    rollRequestState.dragActive = dragging;
+}
+
+export {
+    getNewGroupData,
+    getNewRollData,
+    getRequestGroupsSnapshot,
+    rollRequestState,
+    updateDragState,
+    updateGMDialogState,
+};

--- a/src/module/apps/gm-dialog/state.svelte.ts
+++ b/src/module/apps/gm-dialog/state.svelte.ts
@@ -1,0 +1,57 @@
+import { actionData } from "../helpers.ts";
+import type { RequestGroup, RequestRoll } from "../types.ts";
+
+/** The GM Dialog svelte state */
+const rollRequestState: { groups: RequestGroup[] } = $state({ groups: [] });
+
+function getNewGroupData(): RequestGroup {
+    return {
+        id: fu.randomID(),
+        rolls: [],
+        title: "",
+    };
+}
+
+function getNewRollData(type: RequestRoll["type"]): RequestRoll {
+    switch (type) {
+        case "action":
+            return {
+                dc: 10,
+                id: fu.randomID(),
+                slug: actionData[0].slug,
+                statistic: actionData[0].statistic,
+                variant: actionData[0].variants.at(0)?.slug,
+                type: "action",
+            };
+        case "check":
+            return {
+                dc: 10,
+                id: fu.randomID(),
+                traits: [],
+                slug: "perception",
+                type: "check",
+            };
+        case "counteract":
+            return {
+                dc: 10,
+                id: fu.randomID(),
+                label: game.i18n.localize("PF2ERequestRolls.GMDialog.Counteract.Label"),
+                slug: "arcana",
+                sourceRank: 0,
+                targetRank: 0,
+                type: "counteract",
+            };
+        default:
+            throw Error(`Unknown type ${type}`);
+    }
+}
+
+function getRequestGroupsSnapshot(): RequestGroup[] {
+    return $state.snapshot(rollRequestState.groups);
+}
+
+function updateGMDialogState(data?: RequestGroup[]): void {
+    rollRequestState.groups = data ?? [getNewGroupData()];
+}
+
+export { getNewGroupData, getNewRollData, getRequestGroupsSnapshot, rollRequestState, updateGMDialogState };

--- a/src/module/apps/helpers.ts
+++ b/src/module/apps/helpers.ts
@@ -245,6 +245,7 @@ async function compressToBase64(groups: RequestGroup[]): Promise<string> {
     for (const group of groups) {
         const mGroup: MinifiedRequestGroup = {
             i: group.id,
+            m: group.macro,
             r: [],
             ...(group.title ? { t: group.title } : {}),
         };
@@ -312,6 +313,7 @@ async function decompressFromBase64(string: string): Promise<RequestGroup[]> {
     for (const group of mGroups) {
         const g: RequestGroup = {
             id: group.i,
+            macro: group.m,
             rolls: [],
             title: group.t ?? "",
         };

--- a/src/module/apps/helpers.ts
+++ b/src/module/apps/helpers.ts
@@ -57,6 +57,8 @@ function prepareActionData(): void {
         }
         actionData.push(data);
     }
+
+    actions.set("spell-attack", game.i18n.localize("PF2E.SpellAttackLabel"));
 }
 
 function prepareSkillData(): void {
@@ -193,7 +195,9 @@ function getLabel(roll: RequestRoll): string | undefined {
                 .replaceAll("$s", allSkills.get(roll.statistic ?? "") ?? "$s");
         case "check":
         case "counteract":
-            return label.replaceAll("$s", allSkills.get(roll.slug) ?? "$s");
+            return label
+                .replaceAll("$s", actions.get(roll.slug) ?? "$s")
+                .replaceAll("$s", allSkills.get(roll.slug) ?? "$s");
         default:
             return label;
     }

--- a/src/module/apps/results-dialog/results-dialog.svelte
+++ b/src/module/apps/results-dialog/results-dialog.svelte
@@ -4,6 +4,7 @@
     import { getInlineLink } from "../helpers.ts";
     import type { CounteractRoll } from "../types.ts";
     import type { DegreeOfSuccessString } from "foundry-pf2e";
+    import { resultState } from "./state.svelte.ts";
 
     const props: ResultsDialogContext = $props();
 
@@ -23,7 +24,7 @@
 </script>
 
 <div class="preview">
-    {#each props.state.results as result (result.userId)}
+    {#each resultState.results as result (result.userId)}
         <div class="result-container">
             <div class="header">
                 <strong>{result.name}</strong>
@@ -52,8 +53,10 @@
                             <span class="outcome {group.outcome}">
                                 {game.i18n.localize(`PF2E.Check.Result.Degree.Check.${group.outcome}`)}
                             </span>
-                            {#if group.reroll === "hero-point"}
+                            {#if group.reroll === "hero-points"}
                                 <i class="fa-solid fa-hospital-symbol reroll-indicator"></i>
+                            {:else if group.reroll === "mythic-points"}
+                                <i class="fa-solid fa-circle-m reroll-indicator"></i>
                             {:else if group.reroll === "other"}
                                 <i class="fa-solid fa-dice reroll-indicator"></i>
                             {/if}

--- a/src/module/apps/results-dialog/results-dialog.ts
+++ b/src/module/apps/results-dialog/results-dialog.ts
@@ -4,16 +4,11 @@ import type {
     ApplicationRenderOptions,
 } from "@pf2e/types/foundry/client/applications/_module.d.mts";
 import type ApplicationV2 from "@pf2e/types/foundry/client/applications/api/application.d.mts";
-import type {
-    ChatContextFlag,
-    ChatMessagePF2e,
-    CheckContextChatFlag,
-    DegreeOfSuccessString,
-} from "@pf2e/types/index.ts";
-import * as R from "remeda";
+import type { ChatMessagePF2e, DegreeOfSuccessString } from "@pf2e/types/index.ts";
 import { SvelteApplicationMixin, SvelteApplicationRenderContext } from "../../svelte-mixin/mixin.svelte.ts";
-import type { RequestGroup, RequestRoll, SocketRollRequest } from "../types.ts";
+import type { RequestRoll, SocketRollRequest } from "../types.ts";
 import Root from "./results-dialog.svelte";
+import { findResultMessage, prepareResults, tryDeleteResult } from "./state.svelte.ts";
 
 class ResultsDialog extends SvelteApplicationMixin<
     AbstractConstructorOf<ApplicationV2> & { DEFAULT_OPTIONS: DeepPartial<ResultsDialogConfiguration> }
@@ -57,17 +52,10 @@ class ResultsDialog extends SvelteApplicationMixin<
         super._preFirstRender(context, options);
 
         this.#hooks.createChatMessage = Hooks.on("createChatMessage", (message: ChatMessagePF2e) => {
-            this.#findResultMessage(message);
+            findResultMessage(message, this.options.request);
         });
         this.#hooks.deleteChatMessage = Hooks.on("deleteChatMessage", (message: ChatMessagePF2e) => {
-            const result = this.$state.results.find((r) => r.userId === message.author?.id);
-            if (result) {
-                const data = this.#findGroupAndRoll(message);
-                if (!data) return;
-                if (result.groups[data.group.id]) {
-                    delete result.groups[data.group.id];
-                }
-            }
+            tryDeleteResult(message, this.options.request);
         });
     }
 
@@ -78,77 +66,13 @@ class ResultsDialog extends SvelteApplicationMixin<
     }
 
     protected override async _prepareContext(_options: ApplicationRenderOptions): Promise<ResultsDialogContext> {
-        const results = this.options.request.users.map((id) => ({
-            groups: {},
-            userId: id,
-            name: game.users.get(id, { strict: true }).character?.name ?? "Unknown",
-        }));
-        for (const message of R.takeLast(game.messages.contents, 10)) {
-            this.#findResultMessage(message, results);
-        }
+        prepareResults(this.options);
+
         return {
             request: this.options.request,
             foundryApp: this,
-            state: {
-                results,
-            },
+            state: {},
         };
-    }
-
-    #findResultMessage(message: ChatMessagePF2e, results?: RollResult[]): void {
-        const data = this.#findGroupAndRoll(message);
-        if (!data) return;
-        const result = (results ?? this.$state.results).find((r) => r.userId === message.author?.id);
-        if (!result) return;
-        const group = result.groups[data.group.id];
-        const reroll = data.context.isReroll
-            ? data.context.options.includes("check:hero-point")
-                ? "hero-point"
-                : "other"
-            : null;
-        if (!group) {
-            result.groups[data.group.id] = {
-                label: data.group.title,
-                messageId: message.id,
-                outcome: data.context.outcome,
-                reroll,
-                roll: data.roll,
-            };
-            return;
-        }
-        group.label = data.group.title;
-        group.messageId = message.id;
-        group.outcome = data.context.outcome;
-        group.reroll = reroll;
-        group.roll = data.roll;
-    }
-
-    #findGroupAndRoll(
-        message: ChatMessagePF2e,
-    ): { context: CheckContextChatFlag; group: RequestGroup; roll: RequestRoll } | null {
-        if (!message.author?.id) return null;
-        const request = this.options.request;
-        if (!request.users.includes(message.author.id)) return null;
-        const context = message.flags.pf2e.context;
-        if (!this.#isCheckMessageContext(context)) return null;
-        const options = context.options;
-        if (!options.includes(`request-rolls-id:${request.id}`)) return null;
-        const rollId = options
-            .find((o) => o.startsWith("request-rolls-roll-id:"))
-            ?.split(":")
-            .at(1);
-        if (!rollId) return null;
-        for (const group of request.groups) {
-            for (const roll of group.rolls) {
-                if (roll.id === rollId) return { context, group, roll };
-            }
-        }
-        return null;
-    }
-
-    #isCheckMessageContext(context?: ChatContextFlag): context is CheckContextChatFlag {
-        if (!context) return false;
-        return "outcome" in context && "unadjustedOutcome" in context;
     }
 }
 
@@ -159,9 +83,7 @@ interface ResultsDialogConfiguration extends ApplicationConfiguration {
 interface ResultsDialogContext extends SvelteApplicationRenderContext {
     foundryApp: ResultsDialog;
     request: SocketRollRequest;
-    state: {
-        results: RollResult[];
-    };
+    state: object;
 }
 
 interface RollResult {
@@ -175,8 +97,8 @@ interface RollResultGroup {
     messageId: string | null;
     outcome?: DegreeOfSuccessString | null;
     roll: RequestRoll;
-    reroll?: "hero-point" | "other" | null;
+    reroll?: string | null;
 }
 
 export { ResultsDialog };
-export type { ResultsDialogContext, RollResult };
+export type { ResultsDialogConfiguration, ResultsDialogContext, RollResult };

--- a/src/module/apps/results-dialog/state.svelte.ts
+++ b/src/module/apps/results-dialog/state.svelte.ts
@@ -1,0 +1,112 @@
+import {
+    type ChatContextFlag,
+    type ChatMessagePF2e,
+    type CheckContextChatFlag,
+    type MacroPF2e,
+} from "@pf2e/types/index.ts";
+import * as R from "remeda";
+import { RequestGroup, RequestRoll, SocketRollRequest } from "../types.ts";
+import type { ResultsDialogConfiguration, RollResult } from "./results-dialog.ts";
+
+/** The Result Dialog svelte state */
+const resultState: { results: RollResult[] } = $state({ results: [] });
+
+function prepareResults(options: ResultsDialogConfiguration): void {
+    const results = options.request.users.map((id) => ({
+        groups: {},
+        userId: id,
+        name: game.users.get(id, { strict: true }).character?.name ?? "Unknown",
+    }));
+    for (const message of R.takeLast(game.messages.contents, 10)) {
+        findResultMessage(message, options.request, results);
+    }
+    resultState.results = results;
+}
+
+function findGroupAndRoll(
+    message: ChatMessagePF2e,
+    request: SocketRollRequest,
+): { context: CheckContextChatFlag; group: RequestGroup; roll: RequestRoll } | null {
+    if (!message.author?.id) return null;
+    if (!request.users.includes(message.author.id)) return null;
+    const context = message.flags.pf2e.context;
+    if (!isCheckMessageContext(context)) return null;
+    const options = context.options;
+    if (!options.includes(`request-rolls-id:${request.id}`)) return null;
+    const rollId = options
+        .find((o) => o.startsWith("request-rolls-roll-id:"))
+        ?.split(":")
+        .at(1);
+    if (!rollId) return null;
+    for (const group of request.groups) {
+        for (const roll of group.rolls) {
+            if (roll.id === rollId) return { context, group, roll };
+        }
+    }
+    return null;
+}
+
+function getRerollKind(options: string[]): string {
+    const rerollKinds = ["hero-points", "mythic-points"];
+    for (const kind of rerollKinds) {
+        if (options.includes(`check:reroll:${kind}`)) return kind;
+    }
+    return "other";
+}
+
+function findResultMessage(message: ChatMessagePF2e, request: SocketRollRequest, results?: RollResult[]): void {
+    const data = findGroupAndRoll(message, request);
+    if (!data) return;
+    const result = (results ?? resultState.results).find((r) => r.userId === message.author?.id);
+    if (!result) return;
+    const reroll = data.context.isReroll ? getRerollKind(data.context.options) : null;
+    result.groups[data.group.id] = {
+        label: data.group.title,
+        messageId: message.id,
+        outcome: data.context.outcome,
+        reroll,
+        roll: data.roll,
+    };
+
+    const macroUUID = data.group.macro;
+    if (macroUUID && data.context.outcome) {
+        // Do not run macros for older chat messages
+        if (Date.now() - message.timestamp > 10_000 && !reroll) return;
+
+        const macro = fu.fromUuidSync<MacroPF2e>(macroUUID);
+        if (!macro) {
+            const text = game.i18n.format("PF2ERequestRolls.GMDialog.Macros.Missing", { uuid: macroUUID });
+            ui.notifications.warn(text, { console: false });
+            return;
+        }
+        const roll = $state.snapshot(result.groups[data.group.id]);
+
+        macro.execute({
+            rrData: {
+                actor: message.actor ?? undefined,
+                token: message.actor?.getActiveTokens(true)?.at(0) ?? undefined,
+                ...R.omit(roll, ["messageId"]),
+                message,
+                rollResult: message.rolls.at(0)?.total ?? 0,
+            },
+            speaker: message.speaker,
+        });
+    }
+}
+
+function tryDeleteResult(message: ChatMessagePF2e, request: SocketRollRequest): void {
+    const result = resultState.results.find((r) => r.userId === message.author?.id);
+    if (!result) return;
+    const data = findGroupAndRoll(message, request);
+    if (!data) return;
+    if (result.groups[data.group.id]) {
+        delete result.groups[data.group.id];
+    }
+}
+
+function isCheckMessageContext(context?: ChatContextFlag): context is CheckContextChatFlag {
+    if (!context) return false;
+    return "outcome" in context && "unadjustedOutcome" in context;
+}
+
+export { findGroupAndRoll, findResultMessage, prepareResults, resultState, tryDeleteResult };

--- a/src/module/apps/types.ts
+++ b/src/module/apps/types.ts
@@ -32,6 +32,7 @@ interface CounteractRoll extends BaseRoll {
 interface RequestGroup {
     rolls: (ActionRoll | CheckRoll | CounteractRoll)[];
     id: string;
+    macro?: string;
     title: string;
 }
 
@@ -84,6 +85,8 @@ interface MinifiedRequestGroup {
     r: (MinifiedActionRoll | MinifiedCheckRoll | MinifiedCounteractRoll)[];
     /** id */
     i: string;
+    /** macro */
+    m?: string;
     /** title */
     t?: string;
 }
@@ -107,7 +110,7 @@ interface SocketCSSUpdate {
     type: "css-update";
 }
 
-type LabeledValue = { label: string; value: string };
+type LabeledValue<T extends string = string> = { label: string; value: T };
 type RequestRoll = ActionRoll | CheckRoll | CounteractRoll;
 type SocketRequest = SocketCSSUpdate | SocketRollRequest;
 

--- a/src/module/components/traits/traits-select.svelte
+++ b/src/module/components/traits/traits-select.svelte
@@ -34,10 +34,47 @@
         empty: game.i18n.localize("PF2E.CompendiumBrowser.TraitsComponent.Empty"),
         nomatch: game.i18n.localize("PF2E.CompendiumBrowser.TraitsComponent.NoMatch"),
     };
+
+    // Svelecte position resolver that puts it on the body
+    function positionResolver(node: HTMLElement) {
+        // Add classes to element, including theme
+        const themed = node.closest(".themed, body");
+        const theme = [...(themed?.classList ?? [])].find((c) => c.startsWith("theme-"));
+        node.classList.add("detached", "pf2e");
+        if (theme) {
+            node.classList.add("themed", theme);
+        }
+
+        let destroyed = false;
+        const selectElement = node.parentElement;
+
+        function positionElement() {
+            if (destroyed) return; // end the request animation loop if destroyed
+
+            if (selectElement && node.classList.contains("is-open")) {
+                const bounds = selectElement.getBoundingClientRect();
+                node.style.left = `${bounds.left}px`;
+                node.style.top = `${bounds.bottom}px`;
+                node.style.minWidth = `${bounds.width}px`;
+            }
+
+            requestAnimationFrame(positionElement);
+        }
+
+        document.body.appendChild(node);
+        positionElement();
+
+        return {
+            destroy: () => {
+                destroyed = false;
+                selectElement?.appendChild(node);
+            },
+        };
+    }
 </script>
 
 <div class="traits-select">
-    <Svelecte {...props} {i18n} />
+    <Svelecte {...props} class="request-rolls" {i18n} {positionResolver} />
 </div>
 
 <style lang="scss">
@@ -47,7 +84,9 @@
     }
 
     :global {
-        #pf2e-request-rolls {
+        .svelecte.request-rolls,
+        .sv_dropdown.request-rolls {
+            /** Svelecte Colors */
             --sv-color: var(--color-dark-1);
             --sv-item-btn-color: var(--color-text-trait);
             --sv-item-btn-color-hover: var(--color-text-trait);
@@ -58,6 +97,7 @@
 
             --sv-selection-multi-wrap-padding: 0.15em;
             --sv-selection-gap: 0.2em;
+            --sv-min-height: 2rem; /* match var(--input-height), which is not exposed */
 
             .sv-input--text {
                 width: auto;
@@ -79,61 +119,27 @@
                 }
             }
 
-            .sv-control {
-                cursor: text;
-                width: 96%;
-
-                .sv-buttons {
-                    .sv-btn-separator {
-                        display: none;
-                    }
-                    button[data-action="toggle"] {
-                        display: none;
-                    }
-                }
-            }
-
-            .sv-item--container {
-                border: solid var(--color-border-trait);
-                border-width: 1px 3px;
-            }
-
-            .sv-item--wrap.in-selection {
-                color: var(--color-text-trait);
-                font: 500 var(--font-size-10) var(--sans-serif);
-                text-transform: uppercase;
-                line-height: 1.75em;
-
-                .sv-item--content {
-                    margin: 0 0.25em;
-                }
-            }
-
-            .sv-item--btn {
-                display: inline-flex;
-                width: auto;
-                border-width: 0;
-                background-color: var(--sv-item-btn-bg);
-                border-radius: unset;
-                padding: 0 var(--space-1);
+            /** Undo foundry overrides */
+            button {
                 height: unset;
                 min-height: unset;
-
-                &:hover {
-                    background-color: #c77777;
-                    i {
-                        color: var(--sv-item-btn-color-hover);
-                    }
-                }
+                border-radius: unset;
             }
         }
 
-        .theme-dark #pf2e-request-rolls {
+        body.theme-dark .application:not(.themed) .svelecte.request-rolls,
+        .themed.theme-dark .svelecte.request-rolls,
+        .themed.theme-dark.sv_dropdown.request-rolls {
             --sv-color: var(--color-light-3);
             --sv-control-bg: var(--color-cool-4);
             --sv-icon-color: var(--color-light-3);
             --sv-dropdown-bg: var(--color-dark-2);
             --sv-dropdown-active-bg: #553d3d;
+        }
+
+        body > .sv_dropdown.request-rolls.detached {
+            min-width: 0;
+            z-index: 5000 !important;
         }
     }
 </style>

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -29,6 +29,11 @@
             "HistoryLabel": "History",
             "Label": "Label",
             "LabelPlaceholder": "Enter optional label",
+            "Macros": {
+                "DropHere": "Drop Macro Here",
+                "Tooltip": "This macro will be executed for each roll result. The macro context will have a <strong>rrData</strong> object that contains information about the requested roll, the rolling actor and the roll outcome.",
+                "Missing": "The Macro with UUID {uuid} is missing!"
+            },
             "NoActivePlayersWarning": "No active players found!",
             "NoContentWarning": "Request has no content!",
             "NoPlayersSelectedWarning": "No players were selected!",

--- a/static/module.json
+++ b/static/module.json
@@ -2,10 +2,10 @@
     "id": "pf2e-request-rolls",
     "title": "PF2e Request Rolls",
     "description": "Request rolls from players.",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "compatibility": {
         "minimum": 13,
-        "verified": "13.348"
+        "verified": "13.351"
     },
     "relationships": {
         "systems": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,15 @@
         "moduleResolution": "NodeNext",
         "lib": [
             "ESNext",
-            "DOM"
+            "ESNext.Array",
+            "ESNext.AsyncIterable",
+            "ESNext.Collection",
+            "ESNext.Iterator",
+            "ESNext.Object",
+            "ESNext.Promise",
+            "DOM",
+            "DOM.Iterable",
+            "DOM.AsyncIterable"
         ],
         "noEmit": true,
         "strict": true,


### PR DESCRIPTION
### Macro Information

To attach a macro to a roll request start dragging the macro from the side-bar or the quick-bar to the (then visible) macro drop zone in the GM dialog.

<img width="1050" height="686" alt="image" src="https://github.com/user-attachments/assets/a59450a9-4153-47db-995e-e0f883dc8c4c" />

The macro will then be executed for each related roll chat message that is detected. Note that the macro only runs if the roll result dialog window is still open.

The macro receives an `rrData` object with the following signature:
```ts
interface RequestRollData {
    /** The actor that rolled the check */
    actor?: ActorPF2e;
    /** The actor's active token */
    token?: TokenObjectPF2e;
    /** The request roll group label */
    label: string;
    /** The roll's chat message */
    message: ChatMessagePF2e;
    /** The roll's outcome */
    outcome: "criticalFailure" | "failure" | "success" | "criticalSuccess";
    /** Whether the roll was a reroll and what method was used */
    reroll: "hero-points" | "mythic-points" | null;
    /** The roll result from the chat message */
    rollResult: number;
    /** Information about the requested roll */
    roll: {
        ​dc: number;
​        id: string;
​        slug: string;
​        traits: string[];
​        type: string;
    };
}
```

This should allow for some neat automation with custom logic. 

```js
    if (rrData.outcome === "success" && rrData.roll.slug === "perception") {
        // Do something
    }
```

Also closes #45